### PR TITLE
fix: handle CLI metadata flags before startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,47 @@
 #!/usr/bin/env node
 
-import { startServer } from './server.js';
+import { createRequire } from 'node:module';
 import { getLogger } from './utils/logger.js';
 
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
+const PACKAGE_VERSION = packageJson.version;
 const logger = getLogger('Main');
+
+function printHelp(): void {
+  console.log(`aigroup-finnhub-mcp ${PACKAGE_VERSION}
+
+Finnhub market data MCP server for stocks, crypto, forex, and market analysis.
+
+Usage:
+  aigroup-finnhub-mcp [options]
+
+Options:
+  -h, --help       Show this help message
+  -v, --version    Show package version`);
+}
+
+function handleCliMetadataFlags(args: string[]): boolean {
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(PACKAGE_VERSION);
+    return true;
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return true;
+  }
+
+  return false;
+}
 
 async function main(): Promise<void> {
   try {
+    if (handleCliMetadataFlags(process.argv.slice(2))) {
+      return;
+    }
+
+    const { startServer } = await import('./server.js');
     logger.info('MCP Finnhub Node.js Server Starting...');
     await startServer();
   } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { getConfig, isToolEnabled } from './config.js';
 import { getLogger } from './utils/logger.js';
+import { createRequire } from 'node:module';
 import * as stockMarketData from './tools/stock_market_data.js';
 import * as technicalAnalysis from './tools/technical_analysis.js';
 import * as newsSentiment from './tools/news_sentiment.js';
@@ -24,6 +25,8 @@ import * as projectList from './tools/project_list.js';
 import * as jobStatus from './tools/job_status.js';
 
 const logger = getLogger('Server');
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
 
 // Define all available tools with their handlers
 const toolRegistry: Record<string, { definition: Tool; handler: (args: unknown) => Promise<unknown> }> = {};
@@ -208,7 +211,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: 'aigroup-finnhub-mcp',
-      version: '1.0.0',
+      version: packageJson.version,
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary
- handle `--version`/`-v` and `--help`/`-h` before importing and starting the MCP server
- avoid starting stdio/logging side effects for metadata-only CLI commands
- source the MCP server version from `package.json`

## Verification
- `npm install` (runs prepare/build)
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `node dist/index.js --version` -> `1.2.1`
- `node dist/index.js -v` -> `1.2.1`
- `node dist/index.js --help`
